### PR TITLE
fixing logs ownership

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,6 +20,7 @@ RUN conda env update -n base -f ./flask_app/environment.yml \
 
 COPY . /backend
 WORKDIR /backend/flask_app
+RUN chmod 777 /backend/flask_app/logs
 
 
 CMD ["uwsgi", "--ini", "app.ini:uwsgi-docker"]


### PR DESCRIPTION
Fixing a reported error:

> The docker image of the standalone version is not working correctly. While I can reach the job submission page, after submitting, I get an error:
>„Submit Error Error occured while submiting job: Error: Request failed with status code 500”
>
>In the terminal where the docker is run I can also see some errors:
>„PermissionError: [Errno 13] Permission denied: '/backend/flask_app/logs/logs.log'”